### PR TITLE
✨ Feature - create-route-trigger 토픽 생성 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ run {
 dependencies {
     implementation("org.apache.spark:spark-sql_2.12:3.4.1")
     implementation("org.apache.spark:spark-sql-kafka-0-10_2.12:3.4.1")
+    implementation("org.apache.kafka:kafka-clients")
     runtimeOnly("org.apache.spark:spark-token-provider-kafka-0-10_2.12:3.4.1")
     implementation("org.apache.hbase:hbase-client:2.6.2") {
         exclude group: 'org.slf4j', module: 'slf4j-reload4j'

--- a/src/main/java/com/dongkyeom/spark/streamer/KafkaTriggerProducer.java
+++ b/src/main/java/com/dongkyeom/spark/streamer/KafkaTriggerProducer.java
@@ -1,0 +1,26 @@
+package com.dongkyeom.spark.streamer;
+
+import org.apache.kafka.clients.producer.*;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import java.util.Properties;
+
+public class KafkaTriggerProducer {
+    private final KafkaProducer<String, String> producer;
+
+    public KafkaTriggerProducer() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka-1:29092,kafka-2:29093,kafka-3:29094");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        this.producer = new KafkaProducer<>(props);
+    }
+
+    public void send(String key, String value) {
+        producer.send(new ProducerRecord<>("create-route-trigger", key, value));
+    }
+
+    public void close() {
+        producer.close();
+    }
+}

--- a/src/main/java/com/dongkyeom/spark/streamer/SparkGpsProcessor.java
+++ b/src/main/java/com/dongkyeom/spark/streamer/SparkGpsProcessor.java
@@ -1,11 +1,23 @@
 package com.dongkyeom.spark.streamer;
 
-import org.apache.spark.sql.*;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.ForeachWriter;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.streaming.StreamingQuery;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 
-import static org.apache.spark.sql.functions.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.spark.sql.functions.col;
+import static org.apache.spark.sql.functions.from_json;
+import static org.apache.spark.sql.functions.to_timestamp;
+import static org.apache.spark.sql.functions.window;
 
 public class SparkGpsProcessor {
 
@@ -21,23 +33,24 @@ public class SparkGpsProcessor {
         StructType schema = new StructType()
                 .add("trip_id", DataTypes.StringType)
                 .add("agent_id", DataTypes.StringType)
-                .add("latitude", DataTypes.DoubleType)
-                .add("longitude", DataTypes.DoubleType)
-                .add("timestamp", DataTypes.LongType);
+                .add("latitude", DataTypes.StringType)
+                .add("longitude", DataTypes.StringType)
+                .add("timestamp", DataTypes.StringType);
 
         // Kafka 스트리밍 데이터 읽기
         Dataset<Row> kafkaStream = spark.readStream()
                 .format("kafka")
                 .option("kafka.bootstrap.servers", "kafka-1:29092,kafka-2:29093,kafka-3:29094")
                 .option("subscribe", "raw-gps")
-                .option("startingOffsets", "earliest")
+                .option("startingOffsets", "latest")          // ← 이 설정이 중요
+                .option("failOnDataLoss", "false")            // ← 토픽이 없거나 중간에 사라져도 중단 X
                 .load();
 
         // Kafka 메시지 파싱
         Dataset<Row> parsed = kafkaStream
                 .selectExpr("CAST(key AS STRING) as trip_id_key", "CAST(value AS STRING) as json_value")
                 .select(
-                        col("trip_id_key"),
+                        col("trip_id_key").cast("long").alias("trip_id_key"),
                         from_json(col("json_value"), schema).alias("data")
                 )
                 .select(
@@ -48,8 +61,11 @@ public class SparkGpsProcessor {
                         col("data.longitude"),
                         col("data.timestamp")
                 )
-                // timestamp(long) → timestamp 타입으로 변환
-                .withColumn("timestamp", to_timestamp(from_unixtime(col("timestamp").divide(1000))));
+                .withColumn("trip_id", col("trip_id").cast("long"))
+                .withColumn("agent_id", col("agent_id").cast("long"))
+                .withColumn("latitude", col("latitude").cast("double"))
+                .withColumn("longitude", col("longitude").cast("double"))
+                .withColumn("timestamp", to_timestamp(col("timestamp"), "yyyy-MM-dd HH:mm:ss"));
 
         // Watermark 설정 (지연 허용 시간)
         Dataset<Row> gpsDataWithWatermark = parsed
@@ -59,7 +75,7 @@ public class SparkGpsProcessor {
         Dataset<Row> countPerTripId = gpsDataWithWatermark
                 .groupBy(
                         col("trip_id"),
-                        window(col("timestamp"), "10 minutes")
+                        window(col("timestamp"), "60 minutes")
                 )
                 .count()
                 .filter("count >= 2")
@@ -75,11 +91,14 @@ public class SparkGpsProcessor {
                 .foreach(new ForeachWriter<Row>() {
 
                     private HBaseWriter writer;
+                    private KafkaTriggerProducer producer;
+                    private final Map<String, List<Row>> buffer = new HashMap<>();
 
                     @Override
                     public boolean open(long partitionId, long version) {
                         try {
                             writer = new HBaseWriter();
+                            producer = new KafkaTriggerProducer();
                             return true;
                         } catch (Exception e) {
                             e.printStackTrace();
@@ -90,20 +109,63 @@ public class SparkGpsProcessor {
                     @Override
                     public void process(Row row) {
                         try {
-                            String tripId = row.getAs("trip_id");
-                            String json = row.json();
-                            writer.writeToHBase(tripId, json);
+                            String tripId = row.getAs("trip_id").toString();
+
+                            // HBase 저장
+                            try {
+                                writer.writeToHBase(tripId, row.json());
+                            } catch (Exception e) {
+                                System.err.println("[HBase] ERROR writing to HBase: " + e.getMessage());
+                                e.printStackTrace();
+                            }
+
+                            // 버퍼에 저장
+                            buffer.computeIfAbsent(tripId, k -> new ArrayList<>()).add(row);
+                            int size = buffer.get(tripId).size();
+
+                            // 버퍼에 2개 이상 모이면 Kafka로 트리거 메시지 발행
+                            if (size >= 2) {
+                                List<Row> gpsList = buffer.get(tripId);
+                                gpsList.sort(Comparator.comparing(r -> ((java.sql.Timestamp) r.getAs("timestamp")).getTime()));
+
+                                Row fromRow = gpsList.get(0);
+                                Row toRow = gpsList.get(1);
+
+                                String message = String.format(
+                                        "{ \"from\": {\"trip_id\": \"%s\", \"agent_id\": \"%s\", \"latitude\": %f, \"longitude\": %f}, " +
+                                                "\"to\": {\"trip_id\": \"%s\", \"agent_id\": \"%s\", \"latitude\": %f, \"longitude\": %f} }",
+                                        fromRow.getAs("trip_id").toString(),
+                                        fromRow.getAs("agent_id").toString(),
+                                        (Double) fromRow.getAs("latitude"),
+                                        (Double) fromRow.getAs("longitude"),
+                                        toRow.getAs("trip_id").toString(),
+                                        toRow.getAs("agent_id").toString(),
+                                        (Double) toRow.getAs("latitude"),
+                                        (Double) toRow.getAs("longitude")
+                                );
+
+                                try {
+                                    producer.send(tripId, message);
+                                } catch (Exception e) {
+                                    System.err.println("[Kafka] ERROR sending message: " + e.getMessage());
+                                    e.printStackTrace();
+                                }
+
+                                gpsList.remove(0);
+                            }
+
                         } catch (Exception e) {
+                            System.err.println("[process] ERROR in process(): " + e.getMessage());
                             e.printStackTrace();
                         }
                     }
 
+
                     @Override
                     public void close(Throwable errorOrNull) {
                         try {
-                            if (writer != null) {
-                                writer.close();
-                            }
+                            if (writer != null) writer.close();
+                            if (producer != null) producer.close();
                         } catch (Exception e) {
                             e.printStackTrace();
                         }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #1 

어떤 변경사항이 있었나요?
- [x] ✨ Feature: New feature
- [ ] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- create-route-trigger 토픽 생성 로직 구현
Kafka에 append된 데이터를 consume 하되, 동일 trip_id에 대해선 버퍼에 최대 두 개의 데이터만 갖고있습니다. 만약 버퍼에 쌓인 데이터가 두 개 이상이 된다면, create-route-trigger 토픽을 발행하고 더 이전에 발행된 trip_id를 키로 갖는 데이터를 버퍼에서 지웁니다.

create-route-trigger는 아래와 같이 구성됩니다.
```
{
	"from": {
		"trip_id": String,
		"agent_id": String,
		"latitude": Double,
		"longitude": Double
	},
	"to": {
		"trip_id": String,
		"agent_id": String,
		"latitude": Double,
		"longitude": Double
	}
}
```

해당 데이터는 main server에서 다시 consume하여 경로를 생성하는 데 사용됩니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A